### PR TITLE
Add inventory and refine role for OS

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,2 +1,0 @@
-[honeypot]
-server ansible_host=YOUR_SERVER_IP ansible_user=YOUR_USER

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,19 @@
+[honeypot]
+win_honeypot ansible_host=192.168.100.3
+
+[honeypot:vars]
+ansible_user=ansible
+ansible_password=Azerty11
+ansible_connection=winrm
+ansible_port=5985
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+ansible_become=false
+
+[sensor]
+linux_sensor ansible_host=192.168.100.10
+
+[sensor:vars]
+ansible_user=root
+ansible_connection=ssh
+ansible_become=true

--- a/ansible/roles/honeypot/tasks/main.yml
+++ b/ansible/roles/honeypot/tasks/main.yml
@@ -4,18 +4,24 @@
     name: docker.io
     state: present
   become: yes
+  when: ansible_os_family != 'Windows'
+  tags: docker
 
 - name: Install docker-compose
   apt:
     name: docker-compose
     state: present
   become: yes
+  when: ansible_os_family != 'Windows'
+  tags: docker
 
 - name: Copy docker-compose
   copy:
     src: ../../../../docker-compose.yml
     dest: /opt/honeypot/docker-compose.yml
   become: yes
+  when: ansible_os_family != 'Windows'
+  tags: docker
 
 
 - name: Copy suricata config
@@ -23,12 +29,16 @@
     src: ../../../../suricata
     dest: /opt/honeypot/suricata
   become: yes
+  when: ansible_os_family != 'Windows'
+  tags: docker
 
 - name: Deploy containers
   command: docker-compose up -d
   args:
     chdir: /opt/honeypot
   become: yes
+  when: ansible_os_family != 'Windows'
+  tags: docker
 
 - name: Schedule Suricata rule update
   cron:
@@ -38,26 +48,36 @@
     minute: 0
     hour: 3
   become: yes
+  when: ansible_os_family != 'Windows'
+  tags: docker
 
 - name: Create lure directory
   win_file:
     path: C:\\ImportantData
     state: directory
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Copy lure files
   win_copy:
     src: ../files/lures/
     dest: C:\\ImportantData
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Copy monitoring scripts
   win_copy:
     src: ../../../scripts/
     dest: C:\\HoneypotScripts
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Copy wallpaper
   win_copy:
     src: ../files/wallpaper.b64
     dest: C:\\HoneypotScripts\\wallpaper.b64
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Schedule session recorder
   win_scheduled_task:
@@ -69,6 +89,8 @@
     triggers:
       - logon
     state: present
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Schedule command logger
   win_scheduled_task:
@@ -80,6 +102,8 @@
     triggers:
       - logon
     state: present
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Schedule lure rotation
   win_scheduled_task:
@@ -91,6 +115,8 @@
     triggers:
       - daily
     state: present
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Schedule keystroke logger
   win_scheduled_task:
@@ -102,6 +128,8 @@
     triggers:
       - logon
     state: present
+  when: ansible_os_family == 'Windows'
+  tags: powershell
 
 - name: Setup desktop appearance
   win_scheduled_task:
@@ -113,3 +141,5 @@
     triggers:
       - logon
     state: present
+  when: ansible_os_family == 'Windows'
+  tags: powershell

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,4 +1,10 @@
 ---
+- hosts: sensor
+  gather_facts: yes
+  become: yes
+  roles:
+    - honeypot
+
 - hosts: honeypot
   gather_facts: yes
   roles:


### PR DESCRIPTION
## Summary
- create inventory for Windows honeypot and Debian sensor
- apply honeypot role to each host type in site.yml
- limit tasks in the honeypot role to the appropriate OS with tags
